### PR TITLE
Add Data Persistence

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
@@ -17,13 +17,13 @@ MonoBehaviour:
     m_SerializedData: []
   m_GUID: 5b6049980aecf1d4fad1bd3b00310627
   m_SerializeEntries:
-  - m_GUID: d8ad1e5cc2fe29f439c0a5a0553c6de1
-    m_Address: Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
+  - m_GUID: bda3aa2b3002f024a83508824578bea0
+    m_Address: Assets/Localization/Tables/SettingsUITable Shared Data.asset
     m_ReadOnly: 1
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: bda3aa2b3002f024a83508824578bea0
-    m_Address: Assets/Localization/Tables/SettingsUITable Shared Data.asset
+  - m_GUID: d8ad1e5cc2fe29f439c0a5a0553c6de1
+    m_Address: Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
     m_ReadOnly: 1
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-French (fr).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-French (fr).asset
@@ -17,14 +17,14 @@ MonoBehaviour:
     m_SerializedData: []
   m_GUID: 87710996e8cad4b4d9ed81b82708160f
   m_SerializeEntries:
-  - m_GUID: b3613056dc57f97498af1140e62d77d0
-    m_Address: SettingsUITable_fr
+  - m_GUID: 7aceffdea21408745a366fd245561f6e
+    m_Address: ExceptionMessagesTable_fr
     m_ReadOnly: 1
     m_SerializedLabels:
     - Locale-fr
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: 7aceffdea21408745a366fd245561f6e
-    m_Address: ExceptionMessagesTable_fr
+  - m_GUID: b3613056dc57f97498af1140e62d77d0
+    m_Address: SettingsUITable_fr
     m_ReadOnly: 1
     m_SerializedLabels:
     - Locale-fr

--- a/Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
+++ b/Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
@@ -31,6 +31,34 @@ MonoBehaviour:
     m_Key: DailyLevelsLoadingCheckInternetGenericError
     m_Metadata:
       m_Items: []
+  - m_Id: 13644265484328960
+    m_Key: CloudSaveGenericError
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646760772247552
+    m_Key: CloudSaveLoadGenericError
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646840803762176
+    m_Key: CloudSaveLoadRateLimitedError
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646904376827904
+    m_Key: CloudSaveSaveGenericError
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646923305721856
+    m_Key: CloudSaveSaveRateLimitedError
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646945950769152
+    m_Key: CloudSaveDeleteGenericError
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646978326601728
+    m_Key: CloudSaveDeleteRateLimitedError
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/Tables/ExceptionMessagesTable_en.asset
+++ b/Assets/Localization/Tables/ExceptionMessagesTable_en.asset
@@ -38,6 +38,42 @@ MonoBehaviour:
       Try checking your internet connection...
     m_Metadata:
       m_Items: []
+  - m_Id: 13644265484328960
+    m_Localized: Sorry, there seems to have been a problem. Try checking your internet
+      connection and restart the game...
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646760772247552
+    m_Localized: Sorry, there seems to have been a problem loading your data. To
+      avoid losing any data, try checking your internet connection and restart the
+      game...
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646840803762176
+    m_Localized: Sorry, there seems to have been an internal error loading your data.
+      To avoid losing any data, please try again later...
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646904376827904
+    m_Localized: Sorry, there seems to have been a problem saving your data. Try
+      checking your internet connection...
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646923305721856
+    m_Localized: Sorry, there seems to have been an internal error saving your data.
+      Your data won't be saved, please try again later...
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646945950769152
+    m_Localized: Sorry, there seems to have been a problem deleting your data. Try
+      checking your internet connection and try again...
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646978326601728
+    m_Localized: Sorry, there seems to have been an internal error deleting your
+      data. Please try again later...
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/Tables/ExceptionMessagesTable_fr.asset
+++ b/Assets/Localization/Tables/ExceptionMessagesTable_fr.asset
@@ -24,18 +24,59 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 2259911057408
-    m_Localized: "Nous sommes d\xE9sol\xE9, il semble y avoir eu un probl\xE8me lors
-      du chargement du niveau. Veuillez v\xE9rifier votre connexion internet..."
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors du chargement du niveau. Veuillez v\xE9rifier votre connexion internet..."
     m_Metadata:
       m_Items: []
   - m_Id: 1872712145444864
-    m_Localized: "Nous sommes d\xE9sol\xE9, il semble y avoir eu un probl\xE8me lors
-      du chargement des niveaux. Veuilez v\xE9rifier votre connexion internet..."
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors du chargement des niveaux. Veuilez v\xE9rifier votre connexion internet..."
     m_Metadata:
       m_Items: []
   - m_Id: 8749922454216704
-    m_Localized: "Nous sommes d\xE9sol\xE9, il semble y avoir eu un probl\xE8me lors
-      du chargement des niveaux du jour. Veuillez v\xE9rifier votre connexion internet..."
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors du chargement des niveaux du jour. Veuillez v\xE9rifier votre connexion
+      internet..."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13644265484328960
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me.
+      Veuillez v\xE9rifier votre connexion internet et r\xE9essayer..."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646760772247552
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors du chargement de vos donn\xE9es. Veuillez v\xE9rifier votre connexion
+      internet et r\xE9essayer"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646840803762176
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu une erreur lors
+      du chargement de vos donn\xE9es. Afin de ne pas perdre votre progression, veuillez
+      r\xE9essayer dans quelques minutes..."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646904376827904
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors de la sauvegarde de vos donn\xE9es. Veuillez v\xE9rifier votre connexion
+      internet et r\xE9essayer..."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646923305721856
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu une erreur lors
+      de la sauvegarde de vos donn\xE9es. Votre progression n'a pas pu \xEAtre sauvegard\xE9e,
+      veuillez r\xE9essayer dans quelques minutes..."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646945950769152
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors de la suppression de vos donn\xE9es. Veuillez v\xE9rifier votre connexion
+      internet et r\xE9essayer..."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 13646978326601728
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu une erreur lors
+      de la suppression de vos donn\xE9es. Veuillez r\xE9essayez dans quelques minutes..."
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -154,6 +154,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &493928570
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 493928572}
+  - component: {fileID: 493928571}
+  m_Layer: 0
+  m_Name: LoadingScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &493928571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 493928570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d96a08811eb52e575ba68dd90ab2e337, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &493928572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 493928570}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -9.24907, y: -0.8635867, z: 10.8493185}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &514934737
 GameObject:
   m_ObjectHideFlags: 0
@@ -472,6 +516,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   defaultLevelSelection: {fileID: 0}
+  editorIsWebGL: 1
+  editorIsMobile: 0
 --- !u!4 &1110262685
 Transform:
   m_ObjectHideFlags: 0
@@ -603,6 +649,50 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e3636791a00ebff47968754ca3cbbd83, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1417298276
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1417298277}
+  - component: {fileID: 1417298278}
+  m_Layer: 0
+  m_Name: DataPersistenceManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1417298277
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417298276}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -9.24907, y: -0.8635867, z: 10.8493185}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1417298278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417298276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d10230ccb7c22a2a840d37a3fddec24, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1464376532
@@ -881,6 +971,111 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1876132828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1876132830}
+  - component: {fileID: 1876132829}
+  - component: {fileID: 1876132831}
+  m_Layer: 0
+  m_Name: Test
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1876132829
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876132828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: ed847d21558cbd342bed8b93d67c5322, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: d36333032fa50739ca07f687e5fc2469, type: 3}
+  m_SortingOrder: 3
+--- !u!4 &1876132830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876132828}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -9.24907, y: -0.8635867, z: 10.8493185}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1876132831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876132828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0676b61471fcf9a24b8444b4b2185903, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1883152637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1883152639}
+  - component: {fileID: 1883152638}
+  m_Layer: 0
+  m_Name: PlayerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1883152638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883152637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8b4f2a69c86ac115be26aa74d1c94be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1883152639
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883152637}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -9.24907, y: -0.8635867, z: 10.8493185}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1912724562
 GameObject:
   m_ObjectHideFlags: 0
@@ -1360,3 +1555,7 @@ SceneRoots:
   - {fileID: 1253212903}
   - {fileID: 619437950}
   - {fileID: 1127480193}
+  - {fileID: 1883152639}
+  - {fileID: 1417298277}
+  - {fileID: 493928572}
+  - {fileID: 1876132830}

--- a/Assets/Scripts/BallMaze/DataPersistence.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05d870bce7dc5d6ec9f191b0f1c8936d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/CloudDataHandler.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/CloudDataHandler.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CloudDataHandler : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/BallMaze/DataPersistence/CloudDataHandler.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/CloudDataHandler.cs
@@ -1,18 +1,275 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unity.Services.Authentication;
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models.Data.Player;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Localization.Settings;
+using SaveOptions = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
 
-public class CloudDataHandler : MonoBehaviour
+
+namespace BallMaze
 {
-    // Start is called before the first frame update
-    void Start()
+    public enum CloudSaveKey
     {
-        
+        coins,
     }
 
-    // Update is called once per frame
-    void Update()
+
+    public enum CloudSaveExceptionType
     {
-        
+        Load,
+        LoadRateLimited,
+        Save,
+        SaveRateLimited,
+        Delete,
+        DeleteRateLimited,
+        Generic
+    }
+
+
+    public struct CloudSaveKeyInfo
+    {
+        public string key { get; }
+        public SaveOptions saveOption { get; }
+
+        public CloudSaveKeyInfo(string key, SaveOptions saveOption)
+        {
+            this.key = key;
+            this.saveOption = saveOption;
+        }
+    }
+
+
+    public class CloudDataHandler
+    {
+        private Dictionary<CloudSaveKey, CloudSaveKeyInfo> _cloudSaveKeys = new Dictionary<CloudSaveKey, CloudSaveKeyInfo>();
+        public bool initialized = false;
+
+
+        /// <summary>
+        /// Use an asynchronous constructor because we have to wait for some services to initialize.
+        /// Since it's not possible to have an asynchronous constructor, we instead have a static method
+        /// that loads the services and then call and return the constructor
+        /// </summary>
+        /// <returns></returns>
+        async public static Task<CloudDataHandler> CloudDataHandlerAsync()
+        {
+            bool error = false;
+            try
+            {
+                await AuthenticationService.Instance.SignInAnonymouslyAsync();
+            }
+            catch (Exception e)
+            {
+                error = true;
+                Debug.LogWarning(e);
+                ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveGenericError"), ExceptionManager.ExceptionAction.RestartGame);
+                _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+            }
+
+            CloudDataHandler cloudDataHandler = new CloudDataHandler();
+            cloudDataHandler.initialized = !error;
+            return cloudDataHandler;
+        }
+
+
+        // Private constructor called by the async static method
+        private CloudDataHandler()
+        {
+            _cloudSaveKeys.Add(CloudSaveKey.coins, new CloudSaveKeyInfo("coins", new SaveOptions(new DefaultWriteAccessClassOptions())));
+        }
+
+
+
+        /// <summary>
+        /// Fetch all data from Cloud Save and return a PlayerData object with the data
+        /// </summary>
+        /// <returns></returns>
+        public async Task<PlayerData> Load()
+        {
+            try
+            {
+                PlayerData playerData = new PlayerData();
+
+                var data = await CloudSaveService.Instance.Data.Player.LoadAllAsync();
+
+                if (data.TryGetValue("coins", out var coins))
+                {
+                    playerData.coins = coins.Value.GetAs<int>();
+                }
+                else
+                {
+                    Debug.Log($"{coins} key not found!");
+                }
+
+                return playerData;
+            }
+            catch (CloudSaveValidationException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Load);
+                return new PlayerData();
+            }
+            catch (CloudSaveRateLimitedException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.LoadRateLimited);
+                return new PlayerData();
+            }
+            catch (CloudSaveException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Load);
+                return new PlayerData();
+            }
+        }
+
+
+        /// <summary>
+        /// Save the given object to the cloud with the given key
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public async Task Save(CloudSaveKey key, object value)
+        {
+            // If Cloud Save is disabled or if there is an error, don't save
+            if (!DataPersistenceManager.isCloudSaveEnabled || ExceptionManager.isError)
+            {
+                return;
+            }
+
+            try
+            {
+                // Retrieve information about the key such as the key string (name) and its save options (public or default)
+                CloudSaveKeyInfo cloudSaveKeyInfo = _cloudSaveKeys[key];
+
+                var data = new Dictionary<string, object> { { cloudSaveKeyInfo.key, value } };
+
+                Debug.Log($"Saving key: {cloudSaveKeyInfo.key} with value: {value}");
+                await CloudSaveService.Instance.Data.Player.SaveAsync(data, cloudSaveKeyInfo.saveOption);
+            }
+            catch (CloudSaveValidationException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Save);
+            }
+            catch (CloudSaveRateLimitedException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.SaveRateLimited);
+            }
+            catch (CloudSaveException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Save);
+            }
+        }
+
+
+        /// <summary>
+        /// Save all given values to the cloud. This is usefull to save all the data in a single batch
+        /// </summary>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public async Task Save(Dictionary<CloudSaveKey, object> values)
+        {
+            try
+            {
+                var defaultSaveOptionData = new Dictionary<string, object>();
+                var publicSaveOptionData = new Dictionary<string, object>();
+
+                foreach (KeyValuePair<CloudSaveKey, object> entry in values)
+                {
+                    CloudSaveKeyInfo cloudSaveKeyInfo = _cloudSaveKeys[entry.Key];
+
+                    if (cloudSaveKeyInfo.saveOption == new SaveOptions(new DefaultWriteAccessClassOptions()))
+                    {
+                        defaultSaveOptionData.Add(cloudSaveKeyInfo.key, entry.Value);
+                    }
+                    else if (cloudSaveKeyInfo.saveOption == new SaveOptions(new PublicWriteAccessClassOptions()))
+                    {
+                        publicSaveOptionData.Add(cloudSaveKeyInfo.key, entry.Value);
+                    }
+
+                }
+
+                await CloudSaveService.Instance.Data.Player.SaveAsync(defaultSaveOptionData, new SaveOptions(new DefaultWriteAccessClassOptions()));
+                await CloudSaveService.Instance.Data.Player.SaveAsync(publicSaveOptionData, new SaveOptions(new PublicWriteAccessClassOptions()));
+            }
+            catch (CloudSaveValidationException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Save);
+            }
+            catch (CloudSaveRateLimitedException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.SaveRateLimited);
+            }
+            catch (CloudSaveException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Save);
+            }
+        }
+
+
+        public async Task Delete()
+        {
+            try
+            {
+                await CloudSaveService.Instance.Data.Player.DeleteAllAsync();
+            }
+            catch (CloudSaveValidationException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Delete);
+            }
+            catch (CloudSaveRateLimitedException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.DeleteRateLimited);
+            }
+            catch (CloudSaveException e)
+            {
+                DisplayCloudSaveException(e, CloudSaveExceptionType.Delete);
+            }
+        }
+
+
+        /// <summary>
+        /// Prints the given exception to the console and displays the exception UI .
+        /// </summary>
+        /// <param name="exception"></param>
+        private void DisplayCloudSaveException(Exception exception, CloudSaveExceptionType exceptionType = CloudSaveExceptionType.Generic)
+        {
+            Debug.LogWarning(exception);
+
+            switch (exceptionType)
+            {
+                case CloudSaveExceptionType.Load:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveLoadGenericError"), ExceptionManager.ExceptionAction.RestartGame);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+                case CloudSaveExceptionType.LoadRateLimited:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveLoadRateLimitedError"), ExceptionManager.ExceptionAction.RestartGame);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+                case CloudSaveExceptionType.Save:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveSaveGenericError"), ExceptionManager.ExceptionAction.RestartGame);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+                case CloudSaveExceptionType.SaveRateLimited:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveSaveRateLimitedError"), ExceptionManager.ExceptionAction.Resume);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+                case CloudSaveExceptionType.Delete:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveDeleteGenericError"), ExceptionManager.ExceptionAction.Resume);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+                case CloudSaveExceptionType.DeleteRateLimited:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveDeleteRateLimitedError"), ExceptionManager.ExceptionAction.RestartGame);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+                default:
+                    ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "CloudSaveGenericError"), ExceptionManager.ExceptionAction.RestartGame);
+                    _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+                    break;
+            }
+        }
     }
 }

--- a/Assets/Scripts/BallMaze/DataPersistence/CloudDataHandler.cs.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/CloudDataHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aeb7f57e9da3f25138c37ad075d4c88b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/Data.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7458a09c121c67ecbb5cf4be380c50a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/Data/PlayerData.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/Data/PlayerData.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace BallMaze
+{
+    [Serializable]
+    public class PlayerData
+    {
+        public long lastUpdated;
+        public int coins;
+        public Dictionary<string, int> defaultLevelsTimes;
+        public int[] dailyLevelsTimes;
+        public List<int> ownedSkins;
+
+
+        public PlayerData()
+        {
+            coins = 0;
+            defaultLevelsTimes = new Dictionary<string, int>();
+            dailyLevelsTimes = new int[5];
+            ownedSkins = new List<int>();
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/DataPersistence/Data/PlayerData.cs.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/Data/PlayerData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: deb6dc55f8f1cacbe83939e1a6d72f9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/DataPersistenceManager.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/DataPersistenceManager.cs
@@ -1,0 +1,182 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using UnityEngine.SceneManagement;
+using System.Threading.Tasks;
+using System;
+
+
+namespace BallMaze
+{
+    // The DataPersistence system has been adapted from the Save Load System by Shaped By Rain Studios found
+    // here https://www.youtube.com/watch?v=aUi9aijvpgs and
+    // here https://github.com/shapedbyrainstudios/save-load-system/blob/5-bug-fixes-and-polish
+    public class DataPersistenceManager : MonoBehaviour
+    {
+        // Singleton pattern
+        private static DataPersistenceManager _instance;
+        public static DataPersistenceManager Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    Debug.LogError("DataPersistenceManager is null!");
+                }
+                return _instance;
+            }
+        }
+
+        private bool disableDataPersistence = false;
+        private bool initializeDataIfNull = true;
+
+        private string fileName = "3dbm_data.json";
+        private bool useEncryption = false;
+
+        private int autoSaveTimeSeconds = 15;
+
+        private PlayerData playerData;
+        private List<IDataPersistence> dataPersistenceObjects;
+        private FileDataHandler fileDataHandler;
+
+
+        private void Awake()
+        {
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            if (disableDataPersistence)
+            {
+                Debug.LogWarning("Data Persistence is currently disabled!");
+            }
+
+            fileDataHandler = new FileDataHandler(Application.persistentDataPath, fileName, useEncryption);
+        }
+
+
+        private void OnEnable()
+        {
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+
+        public void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            dataPersistenceObjects = FindAllDataPersistenceObjects();
+
+            LoadGame();
+
+            AutoSave();
+        }
+
+
+        public void DeleteData()
+        {
+            fileDataHandler.Delete();
+
+            // reload the game so that our data matches the newly selected profile id
+            LoadGame();
+        }
+
+
+        public void NewGame()
+        {
+            playerData = new PlayerData();
+        }
+
+
+        public void LoadGame()
+        {
+            // return right away if data persistence is disabled
+            if (disableDataPersistence)
+            {
+                return;
+            }
+
+            // load any saved data from a file using the data handler
+            playerData = fileDataHandler.Load();
+
+            // start a new game if the data is null and we're configured to initialize data for debugging purposes
+            if (playerData == null && initializeDataIfNull)
+            {
+                NewGame();
+            }
+
+            // if no data can be loaded, don't continue
+            if (playerData == null)
+            {
+                Debug.Log("No data was found. A New Game needs to be started before data can be loaded.");
+                return;
+            }
+
+            // push the loaded data to all other scripts that need it
+            foreach (IDataPersistence dataPersistenceObj in dataPersistenceObjects)
+            {
+                dataPersistenceObj.LoadData(playerData);
+            }
+        }
+
+        public void SaveGame()
+        {
+            // return right away if data persistence is disabled
+            if (disableDataPersistence)
+            {
+                return;
+            }
+
+            // if we don't have any data to save, log a warning here
+            if (playerData == null)
+            {
+                Debug.LogWarning("No data was found. A New Game needs to be started before data can be saved.");
+                return;
+            }
+
+            // pass the data to other scripts so they can update it
+            foreach (IDataPersistence dataPersistenceObj in dataPersistenceObjects)
+            {
+                dataPersistenceObj.SaveData(playerData);
+            }
+
+            // timestamp the data so we know when it was last saved
+            playerData.lastUpdated = DateTime.Now.ToBinary();
+
+            // save that data to a file using the data handler
+            fileDataHandler.Save(playerData);
+        }
+
+
+        private List<IDataPersistence> FindAllDataPersistenceObjects()
+        {
+            // FindObjectsofType takes in an optional boolean to include inactive gameobjects
+            IEnumerable<IDataPersistence> dataPersistenceObjects = FindObjectsOfType<MonoBehaviour>(true)
+                .OfType<IDataPersistence>();
+
+            return new List<IDataPersistence>(dataPersistenceObjects);
+        }
+
+
+        public bool HasPlayerData()
+        {
+            return playerData != null;
+        }
+
+
+
+        private async void AutoSave()
+        {
+            while (true)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(autoSaveTimeSeconds));
+                SaveGame();
+                Debug.Log("Auto Saved Game");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/DataPersistence/DataPersistenceManager.cs.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/DataPersistenceManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d10230ccb7c22a2a840d37a3fddec24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/FileDataHandler.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/FileDataHandler.cs
@@ -1,0 +1,198 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using System.IO;
+
+
+namespace BallMaze
+{
+    public class FileDataHandler
+    {
+        private string dataDirPath = "";
+        private string dataFileName = "";
+        private bool useEncryption = false;
+        private readonly string encryptionCodeWord = "SecretEncryptionCodeWord";
+        private readonly string backupExtension = ".bak";
+
+
+        public FileDataHandler(string dataDirPath, string dataFileName, bool useEncryption)
+        {
+            this.dataDirPath = dataDirPath;
+            this.dataFileName = dataFileName;
+            this.useEncryption = useEncryption;
+        }
+
+
+        public PlayerData Load(bool allowRestoreFromBackup = true)
+        {
+            // use Path.Combine to account for different OS's having different path separators
+            string fullPath = Path.Combine(dataDirPath, dataFileName);
+            PlayerData loadedData = null;
+
+            if (File.Exists(fullPath))
+            {
+                try
+                {
+                    // load the serialized data from the file
+                    string dataToLoad = "";
+                    using (FileStream stream = new FileStream(fullPath, FileMode.Open))
+                    {
+                        using (StreamReader reader = new StreamReader(stream))
+                        {
+                            dataToLoad = reader.ReadToEnd();
+                        }
+                    }
+
+                    // optionally decrypt the data
+                    if (useEncryption)
+                    {
+                        dataToLoad = EncryptDecrypt(dataToLoad);
+                    }
+
+                    // deserialize the data from Json back into the C# object
+                    loadedData = JsonUtility.FromJson<PlayerData>(dataToLoad);
+                }
+                catch (Exception e)
+                {
+                    // since we're calling Load(..) recursively, we need to account for the case where
+                    // the rollback succeeds, but data is still failing to load for some other reason,
+                    // which without this check may cause an infinite recursion loop.
+                    if (allowRestoreFromBackup)
+                    {
+                        Debug.LogWarning("Failed to load data file. Attempting to roll back.\n" + e);
+                        bool rollbackSuccess = AttemptRollback(fullPath);
+                        if (rollbackSuccess)
+                        {
+                            // try to load again recursively
+                            loadedData = Load(false);
+                        }
+                    }
+                    // if we hit this else block, one possibility is that the backup file is also corrupt
+                    else
+                    {
+                        Debug.LogError("Error occured when trying to load file at path: "
+                            + fullPath + " and backup did not work.\n" + e);
+                    }
+                }
+            }
+            return loadedData;
+        }
+
+
+        public void Save(PlayerData data)
+        {
+            // use Path.Combine to account for different OS's having different path separators
+            string fullPath = Path.Combine(dataDirPath, dataFileName);
+            string backupFilePath = fullPath + backupExtension;
+
+            try
+            {
+                // create the directory the file will be written to if it doesn't already exist
+                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+
+                // serialize the C# game data object into Json
+                string dataToStore = JsonUtility.ToJson(data, true);
+
+                // optionally encrypt the data
+                if (useEncryption)
+                {
+                    dataToStore = EncryptDecrypt(dataToStore);
+                }
+
+                // write the serialized data to the file
+                using (FileStream stream = new FileStream(fullPath, FileMode.Create))
+                {
+                    using (StreamWriter writer = new StreamWriter(stream))
+                    {
+                        writer.Write(dataToStore);
+                    }
+                }
+
+                // verify the newly saved file can be loaded successfully
+                PlayerData verifiedPlayerData = Load();
+                // if the data can be verified, back it up
+                if (verifiedPlayerData != null)
+                {
+                    File.Copy(fullPath, backupFilePath, true);
+                }
+                // otherwise, something went wrong and we should throw an exception
+                else
+                {
+                    throw new Exception("Save file could not be verified and backup could not be created.");
+                }
+
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error occured when trying to save data to file: " + fullPath + "\n" + e);
+            }
+        }
+
+
+        public void Delete()
+        {
+            string fullPath = Path.Combine(dataDirPath, dataFileName);
+
+            try
+            {
+                // ensure the data file exists at this path before deleting the directory
+                if (File.Exists(fullPath))
+                {
+                    File.Delete(fullPath);
+                    File.Delete(fullPath + backupExtension);
+                }
+                else
+                {
+                    Debug.LogWarning("Tried to delete profile data, but data was not found at path: " + fullPath);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Failed to delete profile data at path: " + fullPath + "\n" + e);
+            }
+        }
+
+
+        // the below is a simple implementation of XOR encryption
+        private string EncryptDecrypt(string data)
+        {
+            string modifiedData = "";
+            for (int i = 0; i < data.Length; i++)
+            {
+                modifiedData += (char)(data[i] ^ encryptionCodeWord[i % encryptionCodeWord.Length]);
+            }
+            return modifiedData;
+        }
+
+
+        private bool AttemptRollback(string fullPath)
+        {
+            bool success = false;
+            string backupFilePath = fullPath + backupExtension;
+
+            try
+            {
+                // if the file exists, attempt to roll back to it by overwriting the original file
+                if (File.Exists(backupFilePath))
+                {
+                    File.Copy(backupFilePath, fullPath, true);
+                    success = true;
+                    Debug.LogWarning("Had to roll back to backup file at: " + backupFilePath);
+                }
+                // otherwise, we don't yet have a backup file - so there's nothing to roll back to
+                else
+                {
+                    throw new Exception("Tried to roll back, but no backup file exists to roll back to.");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error occured when trying to roll back to backup file at: "
+                    + backupFilePath + "\n" + e);
+            }
+
+            return success;
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/DataPersistence/FileDataHandler.cs.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/FileDataHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 271fb7c7384743251a394f8a0459c147
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/IDataPersistence.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/IDataPersistence.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace BallMaze
+{
+    public interface IDataPersistence
+    {
+        void LoadData(PlayerData data);
+
+        void SaveData(PlayerData data);
+    }
+}

--- a/Assets/Scripts/BallMaze/DataPersistence/IDataPersistence.cs.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/IDataPersistence.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a241c54d42390d2fa8e0a621713b8b95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/SerializableTypes.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/SerializableTypes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a76096c879dd87eab8f05fe923298ae
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/DataPersistence/SerializableTypes/SerializableDictionary.cs
+++ b/Assets/Scripts/BallMaze/DataPersistence/SerializableTypes/SerializableDictionary.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace BallMaze
+{
+    [System.Serializable]
+    public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISerializationCallbackReceiver
+    {
+
+        [SerializeField] private List<TKey> keys = new List<TKey>();
+        [SerializeField] private List<TValue> values = new List<TValue>();
+
+        // save the dictionary to lists
+        public void OnBeforeSerialize()
+        {
+            keys.Clear();
+            values.Clear();
+            foreach (KeyValuePair<TKey, TValue> pair in this)
+            {
+                keys.Add(pair.Key);
+                values.Add(pair.Value);
+            }
+        }
+
+        // load the dictionary from lists
+        public void OnAfterDeserialize()
+        {
+            this.Clear();
+
+            if (keys.Count != values.Count)
+            {
+                Debug.LogError("Tried to deserialize a SerializableDictionary, but the amount of keys ("
+                    + keys.Count + ") does not match the number of values (" + values.Count
+                    + ") which indicates that something went wrong");
+            }
+
+            for (int i = 0; i < keys.Count; i++)
+            {
+                this.Add(keys[i], values[i]);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/DataPersistence/SerializableTypes/SerializableDictionary.cs.meta
+++ b/Assets/Scripts/BallMaze/DataPersistence/SerializableTypes/SerializableDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4af80060aff8b84cda31c7a1b3f51393
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/Exceptions/ExceptionManager.cs
+++ b/Assets/Scripts/BallMaze/Exceptions/ExceptionManager.cs
@@ -8,6 +8,10 @@ namespace BallMaze
 {
     public class ExceptionManager : MonoBehaviour
     {
+        // Boolean to check if an exception is currently being displayed
+        public static bool isError = false;
+
+
         /// <summary>
         /// Displays the given exception message
         /// </summary>
@@ -15,9 +19,10 @@ namespace BallMaze
         /// <param name="action">Defines what buttons to display to the user (by default go back to the main menu)</param>
         public static void ShowExceptionMessage(string message, ExceptionAction action = ExceptionAction.BackToMainMenu)
         {
+            isError = true;
             Debug.Log(message);
             // TODO: UI to display message
-            // TODO: add buttons according to the given action
+            // TODO: add buttons according to the given action, when buttons are clicked, set isError to false
         }
 
 
@@ -26,6 +31,8 @@ namespace BallMaze
         /// </summary>
         public enum ExceptionAction
         {
+            Resume,
+            RestartGame,
             BackToMainMenu,
             BackToLevels
         }

--- a/Assets/Scripts/BallMaze/File/FileManager.cs
+++ b/Assets/Scripts/BallMaze/File/FileManager.cs
@@ -27,9 +27,19 @@ namespace BallMaze {
         /// and a DateTime being the result of the request (the date the file at the given url was last modified </returns>
         public static async Task<Tuple<bool, DateTime>> GetLastUrlModifiedDate(string url)
         {
-            // Make a get request to the given url
-            UnityWebRequest request = UnityWebRequest.Get(url);
-            await request.SendWebRequest();
+            // Make a get request to the given url.
+            // With UniTask, a try catch is needed, because if the user is offline, the request will throw an exception
+            UnityWebRequest request;
+            try
+            {
+                request = UnityWebRequest.Get(url);
+                await request.SendWebRequest();
+            }
+            catch (Exception)
+            {
+                Debug.Log("Error getting last modified date of url: " + url);
+                return new Tuple<bool, DateTime>(false, DateTime.UnixEpoch);
+            }
 
             if (request.responseCode < 299 && string.IsNullOrEmpty(request.error))
             {

--- a/Assets/Scripts/BallMaze/Game/GameManager.cs
+++ b/Assets/Scripts/BallMaze/Game/GameManager.cs
@@ -147,6 +147,10 @@ namespace BallMaze
             if (pause)
             {
                 _lastUnfocus = DateTime.UtcNow;
+
+                // Save the game on Application.Pause() and not on Application.Quit().
+                // This is done because Application.Quit() is not always called on mobile devices (especially older ones)
+                DataPersistenceManager.Instance.SaveGame();
             }
             else
             {
@@ -168,6 +172,8 @@ namespace BallMaze
         private void OnApplicationQuit()
         {
             isQuitting = true;
+
+            DataPersistenceManager.Instance.SaveGame();
         }
 
 
@@ -176,6 +182,8 @@ namespace BallMaze
         /// </summary>
         public void QuitGame()
         {
+            DataPersistenceManager.Instance.SaveGame();
+
             Application.Quit();
 
             // Application.Quit() doesn't work in the editor, so we need to stop the editor manually

--- a/Assets/Scripts/BallMaze/Game/GameManager.cs
+++ b/Assets/Scripts/BallMaze/Game/GameManager.cs
@@ -1,4 +1,3 @@
-using BallMaze;
 using BallMaze.UI;
 using System;
 using System.Collections;
@@ -45,18 +44,31 @@ namespace BallMaze
 
         public DefaultLevelSelection defaultLevelSelection;
 
+        // These two variables are used to test the editor and act as different platforms.
+        // This is primarly used for features like Cloud Save where WebGL and mobile have different implementations
+        [SerializeField] public bool editorIsWebGL = false;
+        [SerializeField] public bool editorIsMobile = false;
+
         public static bool isQuitting = false;
 
 
-        private void Awake()
+        public void Awake()
         {
             _instance = this;
             DontDestroyOnLoad(gameObject);
 
-            _gameState = GameState.MainMenu;
+            _gameState = GameState.Loading;
+
             _lastUnfocus = DateTime.UnixEpoch;
 
             defaultLevelSelection = GetComponent<DefaultLevelSelection>();
+        }
+
+
+        public void Initialize()
+        {
+            Debug.Log("Initializing game");
+            GameObject.Find("DataPersistenceManager").GetComponent<DataPersistenceManager>().Initialize();
         }
 
 
@@ -65,7 +77,7 @@ namespace BallMaze
             // When the player presses escape (or back button on Android)
             if (Input.GetKeyDown(KeyCode.Escape))
             {
-                // If we are playing, show the leve quit confirmation
+                // If we are playing, show the level quit confirmation
                 if (_gameState == GameState.Playing)
                 {
                     // If a modal is opened, we want to close it

--- a/Assets/Scripts/BallMaze/UGS.meta
+++ b/Assets/Scripts/BallMaze/UGS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 971e41f65606a858daa94cc7cb1d0b55
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/UGS/InitializeUnityServices.cs
+++ b/Assets/Scripts/BallMaze/UGS/InitializeUnityServices.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Unity.Services.Core;
+using Unity.Services.Core.Environments;
+using UnityEngine;
+
+public class InitializeUnityServices : MonoBehaviour
+{
+    private static readonly string ENVIRONMENT = "development";
+
+
+    public static async Task<bool> Initialize()
+    {
+        try
+        {
+            var options = new InitializationOptions();
+            options.SetEnvironmentName(ENVIRONMENT);
+
+            await UnityServices.InitializeAsync(options);
+            Debug.Log("Unity Services initialized");
+            return true;
+        }
+        catch (Exception exception)
+        {
+            Debug.LogError($"Failed to initialize Unity Services: {exception}");
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/UGS/InitializeUnityServices.cs.meta
+++ b/Assets/Scripts/BallMaze/UGS/InitializeUnityServices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93b839bc7ad75b8cca8965f903249943
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.device-simulator.devices": "1.0.0",
     "com.unity.feature.development": "1.0.1",
     "com.unity.localization": "1.4.5",
+    "com.unity.services.cloudsave": "3.1.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -119,6 +119,39 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.services.authentication": {
+      "version": "2.7.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
+        "com.unity.services.core": "1.10.1",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.services.cloudsave": {
+      "version": "3.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.services.authentication": "2.6.1",
+        "com.unity.services.core": "1.4.3"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.services.core": {
+      "version": "1.12.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
+        "com.unity.modules.androidjni": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.settings-manager": {
       "version": "2.0.1",
       "depth": 2,


### PR DESCRIPTION
# Description
Add data persistence to the game. This PR adds 2 ways to save and load data:
- File
- Database (using Cloud Save from Unity Gaming Services)

Based on the platform, the user is playing on (WebGL, mobile...), one or the other or both is used.

# List of changes
- Add DataPersistenceManager to handle saving and loading data
- Add FileDataHandler to save and load from file
- Add CloudDataHandler to save and load from Cloud Save
- Add basic PlayerData class to hold the data
- Add InitializeUGSServices to initialize all the services before using them
- Add new localized exception messages for Cloud Save

# Fixes
- Fix awaiting a UnityWebRequest with UniTask throwing an exception when the user is offline