### PR TITLE
Add loading screen

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-Shared.asset
@@ -17,13 +17,13 @@ MonoBehaviour:
     m_SerializedData: []
   m_GUID: 5b6049980aecf1d4fad1bd3b00310627
   m_SerializeEntries:
-  - m_GUID: bda3aa2b3002f024a83508824578bea0
-    m_Address: Assets/Localization/Tables/SettingsUITable Shared Data.asset
+  - m_GUID: d8ad1e5cc2fe29f439c0a5a0553c6de1
+    m_Address: Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
     m_ReadOnly: 1
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: d8ad1e5cc2fe29f439c0a5a0553c6de1
-    m_Address: Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
+  - m_GUID: bda3aa2b3002f024a83508824578bea0
+    m_Address: Assets/Localization/Tables/SettingsUITable Shared Data.asset
     m_ReadOnly: 1
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-French (fr).asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Localization-String-Tables-French (fr).asset
@@ -17,14 +17,14 @@ MonoBehaviour:
     m_SerializedData: []
   m_GUID: 87710996e8cad4b4d9ed81b82708160f
   m_SerializeEntries:
-  - m_GUID: 7aceffdea21408745a366fd245561f6e
-    m_Address: ExceptionMessagesTable_fr
+  - m_GUID: b3613056dc57f97498af1140e62d77d0
+    m_Address: SettingsUITable_fr
     m_ReadOnly: 1
     m_SerializedLabels:
     - Locale-fr
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: b3613056dc57f97498af1140e62d77d0
-    m_Address: SettingsUITable_fr
+  - m_GUID: 7aceffdea21408745a366fd245561f6e
+    m_Address: ExceptionMessagesTable_fr
     m_ReadOnly: 1
     m_SerializedLabels:
     - Locale-fr

--- a/Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
+++ b/Assets/Localization/Tables/ExceptionMessagesTable Shared Data.asset
@@ -59,6 +59,10 @@ MonoBehaviour:
     m_Key: CloudSaveDeleteRateLimitedError
     m_Metadata:
       m_Items: []
+  - m_Id: 14046363074043904
+    m_Key: UnableToStartGame
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/Tables/ExceptionMessagesTable_en.asset
+++ b/Assets/Localization/Tables/ExceptionMessagesTable_en.asset
@@ -74,6 +74,11 @@ MonoBehaviour:
       data. Please try again later...
     m_Metadata:
       m_Items: []
+  - m_Id: 14046363074043904
+    m_Localized: Sorry, there seems to have been a problem loading the game. Try
+      checking your internet connection and try again...
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/Tables/ExceptionMessagesTable_fr.asset
+++ b/Assets/Localization/Tables/ExceptionMessagesTable_fr.asset
@@ -79,6 +79,12 @@ MonoBehaviour:
       de la suppression de vos donn\xE9es. Veuillez r\xE9essayez dans quelques minutes..."
     m_Metadata:
       m_Items: []
+  - m_Id: 14046363074043904
+    m_Localized: "Nous sommes d\xE9sol\xE9s, il semble y avoir eu un probl\xE8me
+      lors du chargement du jeu. Veuillez v\xE9rifier votre connexion internet et
+      r\xE9essayer..."
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -164,6 +164,7 @@ GameObject:
   m_Component:
   - component: {fileID: 493928572}
   - component: {fileID: 493928571}
+  - component: {fileID: 493928573}
   m_Layer: 0
   m_Name: LoadingScreen
   m_TagString: Untagged
@@ -198,6 +199,22 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &493928573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 493928570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: ed847d21558cbd342bed8b93d67c5322, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: 5dba300cd8ce271c98af9a16ef9f5c7f, type: 3}
+  m_SortingOrder: 2
 --- !u!1 &514934737
 GameObject:
   m_ObjectHideFlags: 0
@@ -495,7 +512,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1110262685}
   - component: {fileID: 1110262684}
-  - component: {fileID: 1110262686}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -515,7 +531,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb08129923acd0249891d4eb36c804ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultLevelSelection: {fileID: 0}
   editorIsWebGL: 1
   editorIsMobile: 0
 --- !u!4 &1110262685
@@ -533,18 +548,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1110262686
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110262683}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 320ae54d13458ce489decaeac3616226, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1127480191
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BallMaze/Game/DefaultLevelSelection.cs
+++ b/Assets/Scripts/BallMaze/Game/DefaultLevelSelection.cs
@@ -13,7 +13,7 @@ using UnityEngine.Localization.Settings;
 
 namespace BallMaze
 {
-    public class DefaultLevelSelection : MonoBehaviour
+    public class DefaultLevelSelection
     {
         // Last time the default level files were checked for modification
         private DateTime _lastDefaultLevelFilesModifiedCheck;
@@ -43,7 +43,7 @@ namespace BallMaze
         private bool _forceDownload;
 
 
-        private void Start()
+        public void Initialize()
         {
             // Load the last time the default level files were checked for modification if it exists
             if (PlayerPrefs.HasKey("LastDefaultLevelFilesModifiedCheck"))

--- a/Assets/Scripts/BallMaze/Game/GameManager.cs
+++ b/Assets/Scripts/BallMaze/Game/GameManager.cs
@@ -16,6 +16,7 @@ namespace BallMaze
     /// </summary>
     public enum GameState
     {
+        Loading,
         MainMenu,
         ModeSelection,
         LevelSelection,
@@ -69,6 +70,18 @@ namespace BallMaze
         {
             Debug.Log("Initializing game");
             GameObject.Find("DataPersistenceManager").GetComponent<DataPersistenceManager>().Initialize();
+            defaultLevelSelection.Initialize();
+        }
+
+
+        /// <summary>
+        /// Start the game once it has finished loading
+        /// </summary>
+        public void StartGame()
+        {
+            _gameState = GameState.MainMenu;
+
+            UIManager.Instance.Initialize();
         }
 
 

--- a/Assets/Scripts/BallMaze/LoadingScreen.cs
+++ b/Assets/Scripts/BallMaze/LoadingScreen.cs
@@ -1,0 +1,67 @@
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using System;
+
+
+namespace BallMaze
+{
+    public class LoadingScreen : MonoBehaviour
+    {
+        public static readonly int TIMEOUT = 20;
+
+
+        private async void Start()
+        {
+            // TODO: display loading screen UI
+
+            // Wait for Unity Gaming Services to initialize
+            if (GameManager.Instance.editorIsWebGL)
+            {
+                bool result = await InitializeUnityServices.Initialize();
+                if (!result)
+                {
+                    Debug.Log("Couldn't initialize Unity Services, game unable to load");
+                    GameUnableToLoad();
+                    return;
+                }
+                Debug.Log("Unity Services have been initialized, game starting");
+            }
+
+            // Initialize the game and all its services/components
+            GameManager.Instance.Initialize();
+
+            // UniTask.WhenAll will wait for all tasks to complete
+            // UniTask.WhenAny will wait for the first task to complete (either all the initialization tasks or the timeout task)
+            int position = await UniTask.WhenAny(
+                UniTask.WhenAll(
+                    // If Cloud Save is enabled, wait for the CloudDataHandler to be initialized
+                    DataPersistenceManager.isCloudSaveEnabled
+                        ? UniTask.WaitUntil(() => DataPersistenceManager.cloudDataHandlerInitialized)
+                        : UniTask.CompletedTask
+                ),
+                UniTask.Delay(TimeSpan.FromSeconds(TIMEOUT))
+            );
+
+            // If the position of the task that completed first is 1, it means it's the timeout task
+            if (position == 1)
+            {
+                Debug.Log("Couldn't initialize services, game unable to load");
+                GameUnableToLoad();
+            }
+            else
+            {
+                Debug.Log("Services have been initialized, game launching");
+                GameManager.Instance.StartGame();
+            }
+        }
+
+
+        private void GameUnableToLoad()
+        {
+            // TODO: show error with a button to restart the game, have a small button to show error message? (and add a message as a parameter to this method)
+
+            _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
+            return;
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/LoadingScreen.cs
+++ b/Assets/Scripts/BallMaze/LoadingScreen.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System;
 using UnityEngine.UIElements;
 using BallMaze.UI;
+using UnityEngine.Localization.Settings;
 
 
 namespace BallMaze
@@ -79,8 +80,7 @@ namespace BallMaze
 
         private void GameUnableToLoad()
         {
-            // TODO: show error with a button to restart the game, have a small button to show error message? (and add a message as a parameter to this method)
-
+            ExceptionManager.ShowExceptionMessage(LocalizationSettings.StringDatabase.GetLocalizedString("ExceptionMessagesTable", "UnableToStartGame"), ExceptionManager.ExceptionAction.RestartGame);
             _ = InternetManager.Instance.CheckIsOnlineAndDisplayUI();
             return;
         }

--- a/Assets/Scripts/BallMaze/LoadingScreen.cs.meta
+++ b/Assets/Scripts/BallMaze/LoadingScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d96a08811eb52e575ba68dd90ab2e337
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BallMaze/UI/UIManager.cs
+++ b/Assets/Scripts/BallMaze/UI/UIManager.cs
@@ -78,7 +78,11 @@ namespace BallMaze.UI
             DontDestroyOnLoad(gameObject);
 
             _mainUIDocument = GetComponent<UIDocument>();
+        }
 
+
+        public void Initialize()
+        {
             SetupViews();
         }
 

--- a/Assets/Scripts/BallMaze/UI/Views/ScreenViews/LoadingScreenView.cs
+++ b/Assets/Scripts/BallMaze/UI/Views/ScreenViews/LoadingScreenView.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+
+namespace BallMaze.UI
+{
+    public class LoadingScreenView : ScreenView
+    {
+        // Visual Elements
+        private ProgressBar _loadingProgressBar;
+
+        public LoadingScreenView(VisualElement root) : base(root)
+        {
+
+        }
+
+
+        protected override void SetVisualElements()
+        {
+            _loadingProgressBar = _root.Q<ProgressBar>("loading-screen__loading-progress-bar");
+        }
+
+
+        public void SetProgressBarValue(int value)
+        {
+            _loadingProgressBar.value = value;
+            _loadingProgressBar.title = $"{value}%";
+        }
+    }
+}

--- a/Assets/Scripts/BallMaze/UI/Views/ScreenViews/LoadingScreenView.cs.meta
+++ b/Assets/Scripts/BallMaze/UI/Views/ScreenViews/LoadingScreenView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e954f185d4351461eba1d375a114cf23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/USS/ScreenViews/LoadingScreen.uss
+++ b/Assets/UI/USS/ScreenViews/LoadingScreen.uss
@@ -1,0 +1,5 @@
+#loading-screen__progress-bar > #unity-progress-bar {
+    height: 100%;
+    max-height: 100%;
+    min-height: 100%;
+}

--- a/Assets/UI/USS/ScreenViews/LoadingScreen.uss.meta
+++ b/Assets/UI/USS/ScreenViews/LoadingScreen.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24f88eb7c398d05d5be7da40c24a3810
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Assets/UI/UXML/ScreenViews/LoadingScreenScreenView.uxml
+++ b/Assets/UI/UXML/ScreenViews/LoadingScreenScreenView.uxml
@@ -1,0 +1,7 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI/USS/ScreenViews/LoadingScreen.uss?fileID=7433441132597879392&amp;guid=24f88eb7c398d05d5be7da40c24a3810&amp;type=3#LoadingScreen" />
+    <ui:VisualElement name="loading-screen__background" style="flex-grow: 1; flex-shrink: 0; background-color: rgb(127, 202, 255); align-items: center; justify-content: center; display: none;">
+        <ui:Label tabindex="-1" text="Loading..." parse-escape-sequences="false" display-tooltip-when-elided="true" name="loading-screen__loading-label" enable-rich-text="false" style="-unity-text-align: middle-center; font-size: 30px; -unity-font-style: bold;" />
+        <ui:ProgressBar value="0" title="0%" name="loading-screen__loading-progress-bar" style="width: 30%; -unity-font-style: bold; font-size: 30px; flex-grow: 0; margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0; border-top-left-radius: 50%; border-top-right-radius: 50%; border-bottom-right-radius: 50%; border-bottom-left-radius: 50%;" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/UI/UXML/ScreenViews/LoadingScreenScreenView.uxml.meta
+++ b/Assets/UI/UXML/ScreenViews/LoadingScreenScreenView.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5dba300cd8ce271c98af9a16ef9f5c7f
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
# Description
Add a loading screen to let all services/components load before actually starting the game.

# List of changes
- Add loading screen UI prototype to show the loading progress
- Initialize needed services and components on load. If all of them initialize within a given time, the game starts.
- Add localized error message if the services take too long to initialize